### PR TITLE
Add github-cli in arch antithesis environment

### DIFF
--- a/arch-antithesis-jan2026/Dockerfile
+++ b/arch-antithesis-jan2026/Dockerfile
@@ -34,6 +34,7 @@ RUN pacman -Syyu --noconfirm \
   fzf \
   git \
   git-delta \
+  github-cli \
   gnupg \
   helix \
   htop \


### PR DESCRIPTION
Adds github-cli to the arch-antithesis-jan2026 environment, matching what was already done for arch-daily-feb2025 in b34f130.